### PR TITLE
Adjust validation of vlan name length to full 32 characters.

### DIFF
--- a/schema/ucs/ucsm/config/orgs/lan_connectivity_policies.json
+++ b/schema/ucs/ucsm/config/orgs/lan_connectivity_policies.json
@@ -215,7 +215,7 @@
                   "description":"LAN Connectivity Policy - iSCSI vNIC - VLAN",
                   "type":"string",
                   "default":"",
-                  "pattern":"^[\\-\\.:_a-zA-Z0-9]{0,16}$"
+                  "pattern":"^[\\-\\.:_a-zA-Z0-9]{0,32}$"
                }
             },
             "additionalProperties":false,


### PR DESCRIPTION
Fixes: #13